### PR TITLE
feat: added resetDB function to HornClauseDB (#536)

### DIFF
--- a/include/seahorn/HornClauseDB.hh
+++ b/include/seahorn/HornClauseDB.hh
@@ -207,6 +207,9 @@ public:
   /// Returns the current invariants for the predicate
   Expr getInvariants(Expr pred) const;
 
+  /// Reset the DB and clears it.
+  void resetDB();
+
   std::map<Expr, ExprVector> &getAllConstraints() { return m_constraints; }
   std::map<Expr, ExprVector> &getAllInvariants() { return m_invariants; }
 

--- a/lib/seahorn/HornClauseDB.cc
+++ b/lib/seahorn/HornClauseDB.cc
@@ -156,6 +156,17 @@ Expr HornClauseDB::getInvariants(Expr pred) const {
   return getLemmas(m_invariants, m_rels, pred);
 }
 
+void HornClauseDB::resetDB() {
+  m_rels.clear();
+  m_vars.clear();
+  m_rules.clear();
+  m_queries.clear();
+  m_constraints.clear();
+  m_invariants.clear();
+  m_body_idx.clear();
+  m_head_idx.clear();
+}
+
 raw_ostream &HornClauseDB::write(raw_ostream &o) const {
   std::ostringstream oss;
   oss << "Predicates:\n";


### PR DESCRIPTION
Done in order to allow reseting the DB while keeping the same object.